### PR TITLE
Current implementation gives error while running on GPU, fixed by editing detector.py and first_stage.py

### DIFF
--- a/torch_mtcnn/detector.py
+++ b/torch_mtcnn/detector.py
@@ -79,8 +79,8 @@ def detect_faces(image, min_face_size=20.0,
         img_boxes = get_image_boxes(bounding_boxes, image, size=24)
         img_boxes = torch.FloatTensor(img_boxes)
         output = rnet(img_boxes)
-        offsets = output[0].data.numpy()  # shape [n_boxes, 4]
-        probs = output[1].data.numpy()  # shape [n_boxes, 2]
+        offsets = output[0].cpu().data.numpy()  # shape [n_boxes, 4]
+        probs = output[1].cpu().data.numpy()  # shape [n_boxes, 2]
 
         keep = np.where(probs[:, 1] > thresholds[1])[0]
         bounding_boxes = bounding_boxes[keep]
@@ -100,9 +100,9 @@ def detect_faces(image, min_face_size=20.0,
             return [], []
         img_boxes = torch.FloatTensor(img_boxes)
         output = onet(img_boxes)
-        landmarks = output[0].data.numpy()  # shape [n_boxes, 10]
-        offsets = output[1].data.numpy()  # shape [n_boxes, 4]
-        probs = output[2].data.numpy()  # shape [n_boxes, 2]
+        landmarks = output[0].cpu().data.numpy()  # shape [n_boxes, 10]
+        offsets = output[1].cpu().data.numpy()  # shape [n_boxes, 4]
+        probs = output[2].cpu().data.numpy()  # shape [n_boxes, 2]
 
         keep = np.where(probs[:, 1] > thresholds[2])[0]
         bounding_boxes = bounding_boxes[keep]

--- a/torch_mtcnn/first_stage.py
+++ b/torch_mtcnn/first_stage.py
@@ -31,8 +31,8 @@ def run_first_stage(image, net, scale, threshold):
 
         img = torch.FloatTensor(_preprocess(img))
         output = net(img)
-        probs = output[1].data.numpy()[0, 1, :, :]
-        offsets = output[0].data.numpy()
+        probs = output[1].cpu().data.numpy()[0, 1, :, :]
+        offsets = output[0].cpu().data.numpy()
         # probs: probability of a face at each sliding window
         # offsets: transformations to true bounding boxes
 


### PR DESCRIPTION
Both detector.py and first_stage.py gave the below mentioned error upon running. Made relevant changes to accommodate that error.

> TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.